### PR TITLE
1.13 Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ hs_err_pid*
 .settings
 .classpath
 
+# IntelliJ stuff:
+.idea
+
 # Build:
 /classes/
 target/

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,6 +8,7 @@ database: true
 main: nu.nerd.beastmaster.BeastMaster
 softdepend: [ Multiverse-Core ]
 depend: [ WorldEdit, BlockStore, EntityMeta ]
+api-version: 1.13
 
 permissions:
   beastmaster.console:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>nu.nerd</groupId>
 	<name>BeastMaster</name>
 	<artifactId>${project.name}</artifactId>
-	<version>2.4.0</version>
+	<version>2.4.1</version>
 	<packaging>jar</packaging>
 	<description>Handles custom mob spawning.</description>
 	<url>https://github.com/NerdNu/${project.name}</url>
@@ -30,17 +30,17 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.12.1-R0.1-SNAPSHOT</version>
+			<version>1.13-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldedit</artifactId>
-			<version>6.0.0-SNAPSHOT</version>
+			<version>7.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sothatsit</groupId>
 			<artifactId>blockstore</artifactId>
-			<version>1.4</version>
+			<version>1.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>nu.nerd</groupId>

--- a/src/nu/nerd/beastmaster/commands/BeastLootExecutor.java
+++ b/src/nu/nerd/beastmaster/commands/BeastLootExecutor.java
@@ -1,21 +1,20 @@
 package nu.nerd.beastmaster.commands;
 
-import java.util.Collection;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import org.bukkit.ChatColor;
-import org.bukkit.Sound;
-import org.bukkit.command.Command;
-import org.bukkit.command.CommandSender;
-
 import nu.nerd.beastmaster.BeastMaster;
 import nu.nerd.beastmaster.Drop;
 import nu.nerd.beastmaster.DropSet;
 import nu.nerd.beastmaster.DropType;
 import nu.nerd.beastmaster.objectives.ObjectiveType;
+import org.bukkit.ChatColor;
+import org.bukkit.Sound;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 // ----------------------------------------------------------------------------
 /**
@@ -30,7 +29,7 @@ public class BeastLootExecutor extends ExecutorBase {
         super("beast-loot", "help", "add", "remove", "info", "list",
               "add-drop", "remove-drop", "list-drops",
               "single", "objective", "logged", "sound", "xp",
-              "invulnerable", "glowing");
+              "invulnerable", "glowing", "direct");
     }
 
     // ------------------------------------------------------------------------
@@ -527,6 +526,37 @@ public class BeastLootExecutor extends ExecutorBase {
                 drop.setGlowing(flag);
                 String change = flag ? "Enabled" : "Disabled";
                 sender.sendMessage(ChatColor.GOLD + change + " glow effect of " + drop.getLongDescription());
+                BeastMaster.CONFIG.save();
+                return true;
+            } else if (args[0].equals("direct")) {
+                if (args.length != 4) {
+                    Commands.invalidArguments(sender, getName() + " direct <loot-id> <item-id> <yes-or-no>");
+                    return true;
+                }
+
+                String lootIdArg = args[1];
+                DropSet dropSet = BeastMaster.LOOTS.getDropSet(lootIdArg);
+                if (dropSet == null) {
+                    Commands.errorNull(sender, "loot table", lootIdArg);
+                    return true;
+                }
+
+                String dropIdArg = args[2];
+                Drop drop = dropSet.getDrop(dropIdArg);
+                if (drop == null) {
+                    Commands.errorNull(sender, "drop of " + lootIdArg, dropIdArg);
+                    return true;
+                }
+
+                String yesNoArg = args[3];
+                Boolean flag = Commands.parseBoolean(sender, yesNoArg);
+                if (flag == null) {
+                    return true;
+                }
+
+                drop.setDirect(flag);
+                String change = flag ? "Enabled" : "Disabled";
+                sender.sendMessage(ChatColor.GOLD + change + " direct drop flag of " + drop.getLongDescription());
                 BeastMaster.CONFIG.save();
                 return true;
             }

--- a/src/nu/nerd/beastmaster/commands/Commands.java
+++ b/src/nu/nerd/beastmaster/commands/Commands.java
@@ -1,14 +1,14 @@
 package nu.nerd.beastmaster.commands;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.command.CommandSender;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
-
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.command.CommandSender;
 
 // ----------------------------------------------------------------------------
 /**
@@ -140,28 +140,16 @@ public class Commands {
 
     // ------------------------------------------------------------------------
     /**
-     * Parse a Material, specified as either a case-insensitive name, or an
-     * integer.
+     * Parse a Material, specified as either a case-insensitive name.
      * 
      * @param sender the ComamndSender.
-     * @param materialArg the command argument containing the material name or
-     *        number.
+     * @param materialArg the command argument containing the material name.
      * @return the Material
      */
     public static Material parseMaterial(CommandSender sender, String materialArg) {
-        Material material;
-        try {
-            // Note: number out of range => null.
-            material = Material.getMaterial(Integer.parseInt(materialArg));
-        } catch (NumberFormatException ex) {
-            try {
-                material = Material.valueOf(materialArg.toUpperCase());
-            } catch (IllegalArgumentException ex2) {
-                material = null;
-            }
-        }
+        Material material = Material.getMaterial(materialArg.toUpperCase());
         if (material == null) {
-            sender.sendMessage(ChatColor.RED + materialArg + " is not a valid material name or number.");
+            sender.sendMessage(ChatColor.RED + materialArg + " is not a valid material name.");
         }
         return material;
     }

--- a/src/nu/nerd/beastmaster/objectives/Objective.java
+++ b/src/nu/nerd/beastmaster/objectives/Objective.java
@@ -1,16 +1,15 @@
 package nu.nerd.beastmaster.objectives;
 
-import org.bukkit.Effect;
+import nu.nerd.beastmaster.BeastMaster;
+import nu.nerd.beastmaster.Util;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-
-import nu.nerd.beastmaster.BeastMaster;
-import nu.nerd.beastmaster.Util;
 
 // ----------------------------------------------------------------------------
 /**
@@ -83,13 +82,12 @@ public class Objective {
             }
         }
 
-        World.Spigot spigot = _location.getWorld().spigot();
-        spigot.playEffect(_location,
-                          Effect.TILE_BREAK, Material.GLOWSTONE.getId(), 0,
-                          _objectiveType.getParticleRadius(),
-                          _objectiveType.getParticleRadius(),
-                          _objectiveType.getParticleRadius(), 0,
-                          _objectiveType.getParticleCount(), 16);
+        _location.getWorld().spawnParticle(Particle.BLOCK_CRACK, _location,
+                                                                 _objectiveType.getParticleCount(),
+                                                                 _objectiveType.getParticleRadius(),
+                                                                 _objectiveType.getParticleRadius(),
+                                                                 _objectiveType.getParticleRadius(),
+                                                                 Material.GLOWSTONE);
 
         for (Entity entity : _location.getWorld().getNearbyEntities(_location, 2, 2, 2)) {
             if (entity instanceof Player) {


### PR DESCRIPTION
Proposed changes:

1. Defines `api-version: 1.13` in `plugin.yml`
2. Adds a `direct-to-inventory` flag to Drops. If true, the associated ItemStack will be added to the player's inventory instead of being dropped naturally in the world. 
   * Relatedly, `Drop#isDirect()` and `Drop#setDirect(boolean)` were created.
   * The state of this flag is included in the long description, and it is serialized.
   * The command `/beast-loot direct <loot-id> <item-id> <yes-or-no>` was added.
3. Removed references to numerical item ids in favor of string material names.
4. Changed `Objective` visual effect to use `World#spawnParticle`.
5. Added initial support for WorldEdit 7 schematic API. Needs testing.